### PR TITLE
fix: no-method-error with Grape::Entity < 0.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,9 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'codeclimate-test-reporter', group: :test, require: nil
+
+group :test do
+  gem "rack-test"
+  gem "grape"
+  gem "grape-entity"
+end

--- a/lib/rack/grape/endpoint_json.rb
+++ b/lib/rack/grape/endpoint_json.rb
@@ -2,8 +2,8 @@ module Rack
   module Grape
     module EndpointJson
       def as_json(options = nil)
-        return {}.as_json(options) if body.nil?
-        body.to_hash.as_json(options)
+        return {}.as_json(options) if body.nil? || !body.respond_to?(:as_json)
+        body.as_json(options)
       end
     end
   end

--- a/lib/rack/profiler.rb
+++ b/lib/rack/profiler.rb
@@ -38,7 +38,11 @@ module Rack
       subscribe_to_default
       block.call(self) if block_given?
 
-      if defined?(::Grape::Endpoint)
+      # This patch is required because of bug with Grape-Entity
+      # which is fixed in version 0.5.0
+      if (defined?(::Grape::Endpoint) &&
+          defined?(::GrapeEntity::VERSION) &&
+          Gem::Version.new(::GrapeEntity::VERSION) < Gem::Version.new("0.5.0"))
         ::Grape::Endpoint.include Rack::Grape::EndpointJson
       end
     end

--- a/spec/rack/grape/endpoint_json_spec.rb
+++ b/spec/rack/grape/endpoint_json_spec.rb
@@ -1,0 +1,59 @@
+require "json"
+require "spec_helper"
+require "grape"
+require "grape_entity"
+require "rack/test"
+require "rack/profiler"
+
+describe Rack::Grape::EndpointJson do
+  include Rack::Test::Methods
+  subject { Class.new(Grape::API) }
+  let(:sample_hash) { { ping: :pong } }
+
+  def app
+    subject
+  end
+
+  describe "#as_json" do
+    before do
+      subject.use Rack::Profiler
+    end
+
+    it "working with String" do
+      subject.get "/ping" do
+        "pong"
+      end
+      get "/ping?rack-profiler"
+      expect(JSON.parse(last_response.body)["response"]["body"]).to eql("pong")
+    end
+
+    it "working with NULL" do
+      subject.get "/ping" do
+        nil
+      end
+      get "/ping?rack-profiler"
+      expect(JSON.parse(last_response.body)["response"]["body"]).to eql("")
+    end
+
+    it "working with #present" do
+      entity_mock = Object.new
+      allow(entity_mock).to receive(:represent).and_return(sample_hash.to_json)
+
+      subject.get "/ping" do
+        present Object.new, with: entity_mock
+      end
+      get "/ping?rack-profiler"
+      expect(JSON.parse(last_response.body)["response"]["body"]).to eql(sample_hash.to_json)
+    end
+
+    it "working with Grape::Entity" do
+      entity = Class.new(Grape::Entity) { expose :ping }
+
+      subject.get "/ping" do
+        entity.represent({ ping: :pong }).to_json
+      end
+      get "/ping?rack-profiler"
+      expect(JSON.parse(last_response.body)["response"]["body"]).to eql(sample_hash.to_json)
+    end
+  end
+end


### PR DESCRIPTION
There is no method 'to_hash' for Grape::Entity instance. Just call 'as_json' directly.

https://github.com/ruby-grape/grape-entity/blob/07bdc590754a35750a17554beedf3b8025fc4c08/lib/grape_entity/entity.rb#L488
